### PR TITLE
fix: run `lmms-eval --tasks list` & `lmms-eval --tasks list_with_num` command  correctly

### DIFF
--- a/lmms_eval/__main__.py
+++ b/lmms_eval/__main__.py
@@ -35,7 +35,7 @@ from lmms_eval.evaluator import request_caching_arg_to_dict
 from lmms_eval.loggers import EvaluationTracker, WandbLogger
 
 # from lmms_eval.logging_utils import WandbLogger
-from lmms_eval.tasks import TaskManager
+from lmms_eval.tasks import TaskManager, get_task_dict
 from lmms_eval.utils import (
     handle_non_serializable,
     make_table,
@@ -425,7 +425,7 @@ def cli_evaluate_single(args: Union[argparse.Namespace, None] = None) -> None:
         eval_logger.error("Need to specify task to evaluate.")
         sys.exit()
     elif args.tasks == "list":
-        eval_logger.info("Available Tasks:\n - {}".format(f"\n - ".join(sorted(task_manager.list_all_tasks()))))
+        eval_logger.info("Available Tasks:\n - {}".format(f"\n - ".join(sorted(task_manager.all_tasks))))
         sys.exit()
     elif args.tasks == "list_groups":
         eval_logger.info(task_manager.list_all_tasks(list_subtasks=False, list_tags=False))
@@ -441,7 +441,7 @@ def cli_evaluate_single(args: Union[argparse.Namespace, None] = None) -> None:
             "\n" + "=" * 70 + "\n" + "\n\tYou are trying to check all the numbers in each task." + "\n\tThis action will download the complete dataset." + "\n\tIf the results are not clear initially, call this again." + "\n\n" + "=" * 70
         )
         eval_logger.info(log_message)
-        for task_name in sorted(task_manager.list_all_tasks()):
+        for task_name in sorted(task_manager.all_tasks):
             try:
                 task_dict = get_task_dict([task_name], model_name="llava")
                 task_obj = task_dict[task_name]

--- a/lmms_eval/__main__.py
+++ b/lmms_eval/__main__.py
@@ -443,7 +443,7 @@ def cli_evaluate_single(args: Union[argparse.Namespace, None] = None) -> None:
         eval_logger.info(log_message)
         for task_name in sorted(task_manager.all_tasks):
             try:
-                task_dict = get_task_dict([task_name], model_name="llava")
+                task_dict = get_task_dict([task_name], task_manager=task_manager)
                 task_obj = task_dict[task_name]
                 if type(task_obj) == tuple:
                     group, task_obj = task_obj


### PR DESCRIPTION
This PR restores the `lmms-eval --tasks list` and `lmms-eval --tasks list_with_num` command, fundamental features of **lmms-eval** that ensures users can query available tasks and their corresponding question counts.. Maintaining this feature provides better compatibility for future benchmark variants, such as **vsi-bench-debias**.

### `lmms-eval --tasks list`
> Before: Fail to display the task list correctly.
```bash
This script was launched with accelerate
2026-01-23 00:20:03.458 | INFO     | lmms_eval.__main__:cli_evaluate:308 - Verbosity set to INFO
2026-01-23 00:20:03.558 | INFO     | lmms_eval.__main__:cli_evaluate_single:392 - Evaluation tracker args: {}
2026-01-23 00:20:03.791 | INFO     | lmms_eval.__main__:cli_evaluate_single:428 - Available Tasks:
 - 

 - 

 - 

 - 

 - 

 - 

 - 

 - 

 - 

 - 

 - 

 - 

 - 

 - 

 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 -  
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - -
 - .
 - /
 - /
 - /
 - C
 - C
 - G
 - L
 - L
 - O
 - T
 - T
 - T
 - _
 - _
 - a
 - a
 - a
 - a
 - a
 - a
 - a
 - a
 - b
 - b
 - b
 - c
 - c
 - c
 - c
 - c
 - e
 - e
 - e
 - e
 - e
 - e
 - e
 - e
 - f
 - f
 - g
 - g
 - g
 - g
 - h
 - h
 - h
 - i
 - i
 - i
 - i
 - i
 - i
 - i
 - i
 - k
 - k
 - l
 - l
 - l
 - l
 - m
 - m
 - m
 - n
 - n
 - n
 - n
 - n
 - n
 - n
 - n
 - n
 - o
 - o
 - o
 - o
 - o
 - o
 - o
 - p
 - p
 - p
 - r
 - r
 - s
 - s
 - s
 - s
 - s
 - s
 - s
 - t
 - t
 - t
 - t
 - t
 - t
 - t
 - u
 - u
 - u
 - u
 - v
 - v
 - v
 - v
 - y
 - y
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
 - |
```

> After: Correctly output all registered tasks.
```bash
This script was launched with accelerate
2026-01-23 00:28:20.934 | INFO     | lmms_eval.__main__:cli_evaluate:308 - Verbosity set to INFO
2026-01-23 00:28:21.031 | INFO     | lmms_eval.__main__:cli_evaluate_single:392 - Evaluation tracker args: {}
2026-01-23 00:28:21.036 | INFO     | lmms_eval.__main__:cli_evaluate_single:428 - Available Tasks:
 - vsibench
```

### `lmms-eval --tasks list_with_num`
> Before: No results
```bash
This script was launched with accelerate
2026-01-23 01:14:11.348 | INFO     | lmms_eval.__main__:cli_evaluate:308 - Verbosity set to INFO
2026-01-23 01:14:11.445 | INFO     | lmms_eval.__main__:cli_evaluate_single:392 - Evaluation tracker args: {}
2026-01-23 01:14:11.448 | INFO     | lmms_eval.__main__:cli_evaluate_single:443 - 
======================================================================

        You are trying to check all the numbers in each task.
        This action will download the complete dataset.
        If the results are not clear initially, call this again.

======================================================================
``` 

> After: Correctly output all registered tasks with their numbers.
```bash
This script was launched with accelerate
2026-01-23 01:12:03.028 | INFO     | lmms_eval.__main__:cli_evaluate:308 - Verbosity set to INFO
2026-01-23 01:12:03.130 | INFO     | lmms_eval.__main__:cli_evaluate_single:392 - Evaluation tracker args: {}
2026-01-23 01:12:03.135 | INFO     | lmms_eval.__main__:cli_evaluate_single:443 - 
======================================================================

        You are trying to check all the numbers in each task.
        This action will download the complete dataset.
        If the results are not clear initially, call this again.

======================================================================
Fetching 10 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 7913.78it/s]
2026-01-23 01:12:06.618 | INFO     | lmms_eval.__main__:cli_evaluate_single:452 - 
Task : vsibench
 - #num : 5130
```